### PR TITLE
APLICACIÓN DE TÉCNICA DE REFACTORIZACIÓN: CONSOLIDAR EXPRESIÓN 

### DIFF
--- a/src/Modelo/Proveedores_SQL.java
+++ b/src/Modelo/Proveedores_SQL.java
@@ -35,27 +35,33 @@ public class Proveedores_SQL {
         }
     }
 
-    public List verProveedores (){
-        List<Proveedores> verProveedores = new ArrayList();
-        String SQL = "SELECT * FROM proveedores";
-        try {
-            con = conectar.getConnection();
-            pst = con.prepareStatement(SQL);
-            rs = pst.executeQuery();
-            while (rs.next()) {
-                Proveedores proveedores = new Proveedores();
-                proveedores.setRuc(rs.getString("ruc_prov"));
-                proveedores.setNombre(rs.getString("nom_prov"));
-                proveedores.setTelefono(rs.getString("direc_prov"));
-                proveedores.setDireccion(rs.getString("telf_prov"));
-                verProveedores.add(proveedores);
-            }
-
-        } catch (Exception e) {
-            System.out.println(e.toString());
+public List<Proveedores> verProveedores (){
+    List<Proveedores> verProveedores = new ArrayList<>();
+    String SQL = "SELECT ruc_prov, nom_prov, direc_prov, telf_prov FROM proveedores";
+    try {
+        con = conectar.getConnection();
+        pst = con.prepareStatement(SQL);
+        rs = pst.executeQuery();
+        while (rs.next()) {
+            Proveedores proveedor = new Proveedores();
+            proveedor.setRuc(rs.getString("ruc_prov"));
+            proveedor.setNombre(rs.getString("nom_prov"));
+            proveedor.setDireccion(rs.getString("direc_prov"));
+            proveedor.setTelefono(rs.getString("telf_prov"));
+            verProveedores.add(proveedor);
         }
-        return verProveedores;
+    } catch (Exception e) {
+        System.out.println(e.toString());
+    } finally {
+        try {
+            con.close();
+        } catch (Exception ex) {
+            System.out.println(ex.toString());
+        }
     }
+    return verProveedores;
+}
+
 
     public boolean eliminarProveedores (String ruc){
         String SQL = "DELETE FROM proveedores WHERE ruc_prov = ? ";


### PR DESCRIPTION
Se cambió el tipo de retorno del método a List<Proveedores> para indicar el tipo de objeto que se está devolviendo. Se modificó la consulta SQL para seleccionar solo las columnas necesarias (ruc_prov, nom_prov, direc_prov, telf_prov). Se corrigieron los nombres de columna en las asignaciones de propiedades (setTelefono y setDireccion) para que coincidan con los nombres reales de las columnas. Se agregó un bloque finally para asegurarse de que la conexión se cierre adecuadamente después de su uso.